### PR TITLE
Check alternate chains prior to default chain when providing force_chain

### DIFF
--- a/lib/acme/client.rb
+++ b/lib/acme/client.rb
@@ -169,16 +169,16 @@ class Acme::Client
 
     return pem if force_chain.nil?
 
-    return pem if ChainIdentifier.new(pem).match_name?(force_chain)
-
     alternative_urls = Array(response.headers.dig('link', 'alternate'))
     alternative_urls.each do |alternate_url|
       response = download(alternate_url, format: :pem)
-      pem = response.body
-      if ChainIdentifier.new(pem).match_name?(force_chain)
-        return pem
+      alternate_pem = response.body
+      if ChainIdentifier.new(alternate_pem).match_name?(force_chain)
+        return alternate_pem
       end
     end
+
+    return pem if ChainIdentifier.new(pem).match_name?(force_chain)
 
     raise Acme::Client::Error::ForcedChainNotFound, "Could not find any matching chain for `#{force_chain}`"
   end


### PR DESCRIPTION
This allows for retrieving the alternate chain when both default and alternate contain the provided issuer

### WHY are these changes introduced?

To get rid of misleading upstream in repo https://github.com/84codes/acme-client

### WHAT is this pull request doing?

Applies same patch as used in https://github.com/84codes/acme-client
